### PR TITLE
Bug/removing friend

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -7,6 +7,6 @@ class Invitation < ApplicationRecord
       .select('invitations.*', 'movie_parties.movie_poster_path',
               'movie_parties.movie_title', 'movie_parties.time_date',
               'friendships.friend_id as friend_user_id')
-      .where('friendships.friend_id = ?', user_id)
+      .where(friendships: {friend_id: user_id})
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -7,6 +7,6 @@ class Invitation < ApplicationRecord
       .select('invitations.*', 'movie_parties.movie_poster_path',
               'movie_parties.movie_title', 'movie_parties.time_date',
               'friendships.friend_id as friend_user_id')
-      .where(friendships: {friend_id: user_id})
+      .where(friendships: { friend_id: user_id })
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,9 @@ class User < ApplicationRecord
   end
 
   def remove_friend(friend)
+    invitations = Invitation.find_invitations(friend.id)
+    friendship = friendships.find_by(friend_id: friend.id)
+    Invitation.where(friendship_id: friendship.id).destroy_all
     friends.delete(friend)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,6 @@ class User < ApplicationRecord
   end
 
   def remove_friend(friend)
-    invitations = Invitation.find_invitations(friend.id)
     friendship = friendships.find_by(friend_id: friend.id)
     Invitation.where(friendship_id: friendship.id).destroy_all
     friends.delete(friend)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,21 +36,22 @@ RSpec.describe User do
         expect(user_1.friends.include?(user_2)).to eq false
       end
       
-      it 'removes any invitations after removing a friend who invited you' do
+      it 'removes any invitations after removing a friend you invited to any party' do
         user_1 = FactoryBot.create(:user, email: "user1@email.com")
         user_2 = FactoryBot.create(:user, email: "user2@email.com")
 
         user_2.friends << user_1
-        user_1.friends << user_2
 
-        movie_party = FactoryBot.create(:movie_party, user: user_2)
+        movie_party_1 = FactoryBot.create(:movie_party, user: user_2)
+        movie_party_2 = FactoryBot.create(:movie_party, user: user_2)
 
         friendship = user_2.friendships.find_by(friend_id: user_1.id)
-        Invitation.create(movie_party_id: movie_party.id, friendship_id: friendship.id)
+        Invitation.create(movie_party_id: movie_party_1.id, friendship_id: friendship.id)
+        Invitation.create(movie_party_id: movie_party_2.id, friendship_id: friendship.id)
 
-        user_1.remove_friend(user_2)
+        user_2.remove_friend(user_1)
 
-        expect(user_1.friends.include?(user_2)).to eq false
+        expect(user_2.friends.include?(user_1)).to eq false
 
         invitations = Invitation.find_invitations(user_1.id)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe User do
   end
 
   describe "relationships" do
-    it {should have_many :friendships}
-    it {should have_many :movie_parties}
-    it {should have_many(:friends).through(:friendships)}
+    it { should have_many :friendships }
+    it { should have_many :movie_parties }
+    it { should have_many(:friends).through(:friendships) }
   end
 
   describe 'model method,' do
@@ -30,10 +30,31 @@ RSpec.describe User do
         user_1 = FactoryBot.create(:user, email: "user1@email.com")
         user_2 = FactoryBot.create(:user, email: "user2@email.com")
     
-        user_1.add_friend(user_2)
+        user_1.friends << user_2
         user_1.remove_friend(user_2)
 
         expect(user_1.friends.include?(user_2)).to eq false
+      end
+      
+      it 'removes any invitations after removing a friend who invited you' do
+        user_1 = FactoryBot.create(:user, email: "user1@email.com")
+        user_2 = FactoryBot.create(:user, email: "user2@email.com")
+
+        user_2.friends << user_1
+        user_1.friends << user_2
+
+        movie_party = FactoryBot.create(:movie_party, user: user_2)
+
+        friendship = user_2.friendships.find_by(friend_id: user_1.id)
+        Invitation.create(movie_party_id: movie_party.id, friendship_id: friendship.id)
+
+        user_1.remove_friend(user_2)
+
+        expect(user_1.friends.include?(user_2)).to eq false
+
+        invitations = Invitation.find_invitations(user_1.id)
+
+        expect(invitations.empty?).to eq true
       end
     end
   end


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes the foreign key constraint bug when trying to remove a friend who is invited to 1 or more movie parties

* **What is the current behavior?** (You can also link to an open issue here)

The program doesn't remove the friendship due to a foreign key constraint and therefore can't remove a friend if they are invited to a movie party.

* **What is the new behavior (if this is a feature change)?**

You can remove a friend even if they are invited to a movie party

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

- [x] All Tests are Passing

closes #46
