### PR TITLE
Bug/sad paths movie party creation

### DIFF
--- a/app/controllers/users/movie_parties_controller.rb
+++ b/app/controllers/users/movie_parties_controller.rb
@@ -1,23 +1,40 @@
 class Users::MoviePartiesController < ApplicationController
   def new
     @friends = current_user.friends
-    movie_id = params[:movie_id]
-    @movie = MoviesAPI::Client.movie_details(movie_id)
+    if @friends.empty?
+      flash[:notice] = "You can't create a movie party without friends"
+      redirect_to dashboard_path
+    else
+      movie_id = params[:movie_id]
+      @movie = MoviesAPI::Client.movie_details(movie_id)
+    end
   end
 
   def create
-    @movie_party = MovieParty.new(movie_party_params)
-    @movie_party.time_date = build_date_time
-    current_user.movie_parties << @movie_party
-
-    create_invitation
-
-    flash[:success] = 'Movie Party Created!'
-
-    redirect_to dashboard_path
+    if has_at_least_one_friend
+      create_movie_party
+      create_invitation
+      flash[:success] = 'Movie Party Created!'
+      redirect_to dashboard_path
+    else
+      flash[:alert] = 'Must have at least 1 friend added'
+      redirect_to new_movie_party_path(movie_id: params[:movie_id])
+    end
   end
 
   private
+
+  def has_at_least_one_friend
+    params[:friends].values.any? do |has_email|
+      has_email != 'false'
+    end
+  end
+
+  def create_movie_party
+    @movie_party = MovieParty.new(movie_party_params)
+    @movie_party.time_date = build_date_time
+    current_user.movie_parties << @movie_party
+  end
 
   def create_invitation
     params[:friends].each do |friend_email|

--- a/app/controllers/users/movie_parties_controller.rb
+++ b/app/controllers/users/movie_parties_controller.rb
@@ -11,7 +11,7 @@ class Users::MoviePartiesController < ApplicationController
   end
 
   def create
-    if has_at_least_one_friend
+    if at_least_one_friend
       create_movie_party
       create_invitation
       flash[:success] = 'Movie Party Created!'
@@ -24,7 +24,7 @@ class Users::MoviePartiesController < ApplicationController
 
   private
 
-  def has_at_least_one_friend
+  def at_least_one_friend
     params[:friends].values.any? do |has_email|
       has_email != 'false'
     end

--- a/spec/features/users/movie_parties/new_spec.rb
+++ b/spec/features/users/movie_parties/new_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Creating a movie party page' do
 
     login_with @main_user
 
-    visit new_movie_party_path(movie_id: 0)
+    visit new_movie_party_path(movie_id: 550)
   end
 
   describe 'movie details form' do
@@ -60,6 +60,21 @@ RSpec.describe 'Creating a movie party page' do
           expect(page).to have_content(movie_party.movie_title)
           expect(page).to have_content(movie_party.viewing_date)
           expect(page).to have_content(movie_party.viewing_time)
+        end
+      end
+    end
+
+    context 'unsuccessful creation' do
+      it 'navigates user back to the new page if no friends are added' do
+        within '#movie-details' do
+          fill_in 'time_of_viewing', with: '2:00'
+          click_button 'Create Party'
+        end
+
+        expect(current_path).to eq new_movie_party_path
+
+        within '#flash-message' do
+          expect(page).to have_content('Must have at least 1 friend added')
         end
       end
     end

--- a/spec/features/users/movies/show_spec.rb
+++ b/spec/features/users/movies/show_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Movies Show page' do
   before :each do
-    user = FactoryBot.create(:user)
-    login_with(user)
+    @user = FactoryBot.create(:user)
+    login_with(@user)
 
-    visit "/movies/0"
+    visit movie_url(550)
   end
 
   describe 'Show Page' do
@@ -20,6 +20,28 @@ RSpec.describe 'Movies Show page' do
       expect(page).to have_content("Summary")
       expect(page).to have_content("Cast")
       expect(page).to have_content("3 Reviews")
+    end
+  end
+
+  describe 'create movie party link,' do
+    context 'valid navigation' do
+      it 'allows user to create a movie party if they have at least 1 friend' do
+        @user.friends << FactoryBot.create(:user, email: 'friend@friends.com')
+        click_link 'Create Viewing Party for Movie'
+
+        expect(current_path).to eq new_movie_party_path
+      end
+    end
+
+    context 'invalid navigation' do
+      it 'navigates back to dashboard if user has no friends yet' do
+        click_link 'Create Viewing Party for Movie'
+        
+        expect(current_path).to eq dashboard_path
+        within '#flash-message' do
+          expect(page).to have_content("You can't create a movie party without friends")
+        end
+      end
     end
   end
 end

--- a/spec/services/movies_api/api_calls_spec.rb
+++ b/spec/services/movies_api/api_calls_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'API Calls' do
 
     describe '::movie_details' do
       it 'returns deatils of a specific movie' do
-        movie = MoviesAPI::Client.movie_details(0)
+        movie = MoviesAPI::Client.movie_details(550)
 
         expect(movie).to be_a Hash
         expect(movie['title']).to eq("Fight Club")
@@ -34,7 +34,7 @@ RSpec.describe 'API Calls' do
 
     describe '::movie_credits' do
       it 'returns credits for a specific movie' do
-        movie = MoviesAPI::Client.movie_credits(0)
+        movie = MoviesAPI::Client.movie_credits(550)
 
         expect(movie).to be_a Hash
         expect(movie["cast"][0]['name']).to eq("Edward Norton")
@@ -46,7 +46,7 @@ RSpec.describe 'API Calls' do
 
     describe '::movie_reviews' do
       it 'returns reviews for a specific movie' do
-        movie = MoviesAPI::Client.movie_reviews(0)
+        movie = MoviesAPI::Client.movie_reviews(550)
 
         expect(movie).to be_a Hash
         expect(movie["results"][0]['author']).to eq("Cat Ellington")

--- a/spec/support/fixtures/movies_api_stubs.rb
+++ b/spec/support/fixtures/movies_api_stubs.rb
@@ -10,9 +10,9 @@ RSpec.configure do |config|
     top_rated_movies_mock_path = EndpointStitch::stitch(MoviesAPI::Client::top_rated_movies_endpoint)
     test_endpoint_path = EndpointStitch::stitch('test/endpoint')
     trending_movies_mock_path = EndpointStitch::stitch(MoviesAPI::Client::trending_movies_endpoint)
-    movie_details_mock_path = EndpointStitch::stitch(MoviesAPI::Client::movie_details_endpoint(0))
-    movie_credits_mock_path = EndpointStitch::stitch(MoviesAPI::Client::movie_credits_endpoint(0))
-    movie_reviews_mock_path = EndpointStitch::stitch(MoviesAPI::Client::movie_reviews_endpoint(0))
+    movie_details_mock_path = EndpointStitch::stitch(MoviesAPI::Client::movie_details_endpoint(550))
+    movie_credits_mock_path = EndpointStitch::stitch(MoviesAPI::Client::movie_credits_endpoint(550))
+    movie_reviews_mock_path = EndpointStitch::stitch(MoviesAPI::Client::movie_reviews_endpoint(550))
     upcoming_movies_mock_path = EndpointStitch::stitch(MoviesAPI::Client::upcoming_movies_endpoint)
 
     search_movies_mock_data = MoviesAPIMock::get('search_movie_result.json')


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds checks to new movie party page to make sure that the user has at least 1 friend before being able to create a movie party and must add at least 1 friend to a viewing party

* **What is the current behavior?** (You can also link to an open issue here)

A user is able to create a movie party with no friends. If user creates a movie party a server error occurs but the movie party is still persisted.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

- [x] All Tests are Passing

closes #47 
